### PR TITLE
Optimising SimilarityCalculation and Loading OpenCv in configure

### DIFF
--- a/src/main/java/org/pooledtimeseries/GradientTimeSeries.java
+++ b/src/main/java/org/pooledtimeseries/GradientTimeSeries.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.hadoop.conf.Configuration;
@@ -38,24 +39,20 @@ import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapred.TextInputFormat;
 import org.apache.hadoop.mapred.lib.MultipleTextOutputFormat;
 import org.opencv.core.Core;
-import org.pooledtimeseries.util.ClassScope;
 import org.pooledtimeseries.util.HadoopFileUtil;
+import org.pooledtimeseries.util.PoTUtil;
 
 public class GradientTimeSeries {
-	private static final Logger LOG = Logger.getLogger(SimilarityCalculation.class.getName());
+	private static final Logger LOG = Logger.getLogger(GradientTimeSeries.class.getName());
 
     public static class Map extends MapReduceBase implements Mapper<LongWritable, Text, Text, Text> {
+    	@Override
+    	public void configure(JobConf job) {
+    		super.configure(job);
+    		PoTUtil.loadOpenCV();
+    	}
     	
         public void map(LongWritable key, Text value, OutputCollector<Text, Text> output, Reporter reporter) throws IOException {
-
-        	if (!ClassScope.isLibraryLoaded(Core.NATIVE_LIBRARY_NAME)) {
-        		LOG.info("Trying to load - " + Core.NATIVE_LIBRARY_NAME);
-        		try{
-        			System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
-        		}catch (java.lang.UnsatisfiedLinkError e){
-        			System.load("/mnt/apps/opencv-2.4.11/release/lib/libopencv_java2411.so");
-        		} 
-        	}
         	
             try {
             	File tempFile = new HadoopFileUtil().copyToTempDir(value.toString());
@@ -64,7 +61,9 @@ public class GradientTimeSeries {
                 
                 String ofVector = saveVectors(series1);
                 output.collect(value, new Text(ofVector));
-            } catch (Exception e) {}
+            } catch (Exception e) {
+            	LOG.log(Level.SEVERE, "Exception while calling PoT.getGradientTimeSeries", e);
+            }
         }
 
         private static String saveVectors(double[][] vectors) {

--- a/src/main/java/org/pooledtimeseries/MeanChiSquareDistanceCalculation.java
+++ b/src/main/java/org/pooledtimeseries/MeanChiSquareDistanceCalculation.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
-import org.opencv.core.Core;
 import org.pooledtimeseries.util.HadoopFileUtil;
 
 public class MeanChiSquareDistanceCalculation {
@@ -108,7 +107,6 @@ public class MeanChiSquareDistanceCalculation {
     }
 
     public static void main(String[] args) throws Exception {
-        System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
 
         Configuration baseConf = new Configuration();
 	baseConf.set("mapreduce.job.maps", "96");

--- a/src/main/java/org/pooledtimeseries/MeanChiSquareDistanceCalculation.java
+++ b/src/main/java/org/pooledtimeseries/MeanChiSquareDistanceCalculation.java
@@ -66,8 +66,11 @@ public class MeanChiSquareDistanceCalculation {
             for (String video: videoPaths) {
                 ArrayList<double[][]> multiSeries = new ArrayList<double[][]>();
                 
+                long startIoTime = System.currentTimeMillis();
                 multiSeries.add(PoT.loadTimeSeries(getInputStreamFromHDFS(video + ".of.txt")));
                 multiSeries.add(PoT.loadTimeSeries(getInputStreamFromHDFS(video + ".hog.txt")));
+                
+                LOG.info("Read both series in - " + (System.currentTimeMillis() - startIoTime));
                 
                 FeatureVector fv = new FeatureVector();
                 for (int i = 0; i < multiSeries.size(); i++) {
@@ -78,7 +81,7 @@ public class MeanChiSquareDistanceCalculation {
                 fvList.add(fv);
             }
             
-            LOG.info("Loaded Time Series for pair - " + value);
+            LOG.info("Loaded Time Series for pair in - " + (System.currentTimeMillis() - startTime));
 
             for (int i = 0; i < fvList.get(0).numDim(); i++) {
                 context.write(new IntWritable(i), new DoubleWritable(

--- a/src/main/java/org/pooledtimeseries/MeanChiSquareDistanceCalculation.java
+++ b/src/main/java/org/pooledtimeseries/MeanChiSquareDistanceCalculation.java
@@ -18,7 +18,6 @@
 package org.pooledtimeseries;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.logging.Logger;
 
@@ -38,16 +37,13 @@ import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
 import org.opencv.core.Core;
+import org.pooledtimeseries.util.HadoopFileUtil;
 
 public class MeanChiSquareDistanceCalculation {
 	private static final Logger LOG = Logger.getLogger(MeanChiSquareDistanceCalculation.class.getName());
 	static int videos=0;
     public static class Map extends Mapper<LongWritable, Text, IntWritable, DoubleWritable> {
     	
-    	private InputStream getInputStreamFromHDFS(String pathToHDFS) throws IOException{
-    		Path videoPath = new Path(pathToHDFS.toString());
-    		return videoPath.getFileSystem(new Configuration()).open(videoPath);
-    	}
     	
         public void map(LongWritable key, Text value, Context context) throws IOException, InterruptedException, NumberFormatException {
         	videos++;    
@@ -67,8 +63,8 @@ public class MeanChiSquareDistanceCalculation {
                 ArrayList<double[][]> multiSeries = new ArrayList<double[][]>();
                 
                 long startIoTime = System.currentTimeMillis();
-                multiSeries.add(PoT.loadTimeSeries(getInputStreamFromHDFS(video + ".of.txt")));
-                multiSeries.add(PoT.loadTimeSeries(getInputStreamFromHDFS(video + ".hog.txt")));
+                multiSeries.add(PoT.loadTimeSeries(HadoopFileUtil.getInputStreamFromHDFS(video + ".of.txt")));
+                multiSeries.add(PoT.loadTimeSeries(HadoopFileUtil.getInputStreamFromHDFS(video + ".hog.txt")));
                 
                 LOG.info("Read both series in - " + (System.currentTimeMillis() - startIoTime));
                 

--- a/src/main/java/org/pooledtimeseries/OpticalTimeSeries.java
+++ b/src/main/java/org/pooledtimeseries/OpticalTimeSeries.java
@@ -41,24 +41,20 @@ import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapred.TextInputFormat;
 import org.apache.hadoop.mapred.lib.MultipleTextOutputFormat;
 import org.opencv.core.Core;
-import org.pooledtimeseries.util.ClassScope;
 import org.pooledtimeseries.util.HadoopFileUtil;
+import org.pooledtimeseries.util.PoTUtil;
 
 public class OpticalTimeSeries {
-	private static final Logger LOG = Logger.getLogger(SimilarityCalculation.class.getName());
+	private static final Logger LOG = Logger.getLogger(OpticalTimeSeries.class.getName());
 
     public static class Map extends MapReduceBase implements Mapper<LongWritable, Text, Text, Text> {
+    	@Override
+    	public void configure(JobConf job) {
+    		super.configure(job);
+    		PoTUtil.loadOpenCV();
+    	}
     	
         public void map(LongWritable key, Text value, OutputCollector<Text, Text> output, Reporter reporter) throws IOException {
-        	
-        	if (!ClassScope.isLibraryLoaded(Core.NATIVE_LIBRARY_NAME)) {
-        		LOG.info("Trying to load - " + Core.NATIVE_LIBRARY_NAME);
-        		try{
-        			System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
-        		}catch (java.lang.UnsatisfiedLinkError e){
-        			System.load("/mnt/apps/opencv-2.4.11/release/lib/libopencv_java2411.so");
-        		} 
-        	}
         	
             try {
             	File tempFile = new HadoopFileUtil().copyToTempDir(value.toString());

--- a/src/main/java/org/pooledtimeseries/PoT.java
+++ b/src/main/java/org/pooledtimeseries/PoT.java
@@ -19,9 +19,9 @@ package org.pooledtimeseries;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
-import java.io.FileWriter;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -610,6 +610,11 @@ public class PoT {
 		}
 		
 		scin.close();
+		try {
+			in.close();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
 		return series;
 
 	}

--- a/src/main/java/org/pooledtimeseries/SimilarityCalculation.java
+++ b/src/main/java/org/pooledtimeseries/SimilarityCalculation.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
-import org.opencv.core.Core;
 import org.pooledtimeseries.util.HadoopFileUtil;
 
 public class SimilarityCalculation {
@@ -98,7 +97,6 @@ public class SimilarityCalculation {
 	}
 
 	public static void main(String[] args) throws Exception {
-		System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
 
 		Configuration baseConf = new Configuration();
 		baseConf.set("mapreduce.job.maps", "96");

--- a/src/main/java/org/pooledtimeseries/SimilarityCalculation.java
+++ b/src/main/java/org/pooledtimeseries/SimilarityCalculation.java
@@ -61,17 +61,9 @@ public class SimilarityCalculation {
 			for (String video : videoPaths) {
 				ArrayList<double[][]> multiSeries = new ArrayList<double[][]>();
 
-				File ofCachePath = new HadoopFileUtil().copyToTempDir(video + ".of.txt");
-				File hogCachePath = new HadoopFileUtil().copyToTempDir(video + ".hog.txt");
+				multiSeries.add(PoT.loadTimeSeries(HadoopFileUtil.getInputStreamFromHDFS(video + ".of.txt")));
+                multiSeries.add(PoT.loadTimeSeries(HadoopFileUtil.getInputStreamFromHDFS(video + ".hog.txt")));
                 
-				double[][] series1 = PoT.loadTimeSeries(ofCachePath.toPath());
-				double[][] series2 = PoT.loadTimeSeries(hogCachePath.toPath());
-				
-				hogCachePath.delete();
-				ofCachePath.delete();
-				multiSeries.add(series1);
-				multiSeries.add(series2);
-
 				FeatureVector fv = new FeatureVector();
 				for (int i = 0; i < multiSeries.size(); i++) {
 					fv.feature.add(PoT.computeFeaturesFromSeries(multiSeries.get(i), tws, 1));

--- a/src/main/java/org/pooledtimeseries/util/HadoopFileUtil.java
+++ b/src/main/java/org/pooledtimeseries/util/HadoopFileUtil.java
@@ -20,6 +20,7 @@ package org.pooledtimeseries.util;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.Arrays;
@@ -73,5 +74,10 @@ public class HadoopFileUtil {
 		LOG.info("Available files - " + Arrays.asList(tempDir.listFiles()) );
 		
 		return new File(tempDir.getAbsolutePath() + "/" + videoPath.getName());
+	}
+	
+	public static InputStream getInputStreamFromHDFS(String pathToHDFS) throws IOException{
+		Path videoPath = new Path(pathToHDFS.toString());
+		return videoPath.getFileSystem(new Configuration()).open(videoPath);
 	}
 }

--- a/src/main/java/org/pooledtimeseries/util/PoTUtil.java
+++ b/src/main/java/org/pooledtimeseries/util/PoTUtil.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pooledtimeseries.util;
+
+import java.util.logging.Logger;
+
+import org.opencv.core.Core;
+import org.pooledtimeseries.SimilarityCalculation;
+
+public class PoTUtil {
+	private static final Logger LOG = Logger.getLogger(SimilarityCalculation.class.getName());
+	
+	public static void loadOpenCV(){
+		
+		if (!ClassScope.isLibraryLoaded(Core.NATIVE_LIBRARY_NAME)) {
+    		LOG.info("Trying to load - " + Core.NATIVE_LIBRARY_NAME);
+    		try{
+    			System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
+    		}catch (java.lang.UnsatisfiedLinkError e){
+    			System.load("/mnt/apps/opencv-2.4.11/release/lib/libopencv_java2411.so");
+    		} 
+    	}
+	}
+}

--- a/src/main/java/org/pooledtimeseries/util/PoTUtil.java
+++ b/src/main/java/org/pooledtimeseries/util/PoTUtil.java
@@ -23,17 +23,22 @@ import org.opencv.core.Core;
 import org.pooledtimeseries.SimilarityCalculation;
 
 public class PoTUtil {
+	private static final String DEFAULT_LIB_PATH = "/mnt/apps/opencv-2.4.11/release/lib/libopencv_java2411.so";
 	private static final Logger LOG = Logger.getLogger(SimilarityCalculation.class.getName());
 	
-	public static void loadOpenCV(){
+	public static void loadOpenCV(String libraryPath){
 		
 		if (!ClassScope.isLibraryLoaded(Core.NATIVE_LIBRARY_NAME)) {
     		LOG.info("Trying to load - " + Core.NATIVE_LIBRARY_NAME);
     		try{
     			System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
     		}catch (java.lang.UnsatisfiedLinkError e){
-    			System.load("/mnt/apps/opencv-2.4.11/release/lib/libopencv_java2411.so");
+    			System.load(libraryPath);
     		} 
     	}
+	}
+	
+	public static void loadOpenCV(){
+		loadOpenCV(DEFAULT_LIB_PATH);
 	}
 }


### PR DESCRIPTION
- Reading from HDFS input stream in SimilarityCalculation same as MeanChiSquare
- Loading OpenCv in configure
- Removing unnecessary loadLibrary call
- Added IO timing in MeanChiSquare
